### PR TITLE
multi-institute-config

### DIFF
--- a/irodscollector_multi.ini
+++ b/irodscollector_multi.ini
@@ -1,0 +1,56 @@
+#
+# template of a configuration file for EUDAT's irodscollector
+#
+
+# section containing the logging options
+[Logging]
+log_file=eudatacct.log
+
+# section containing the properties to access the accounting server
+# to get statistical data and report them
+[Report]
+# base URL of the accounting server to be used
+base_url=https://accounting.eudat.eu
+# domain: either eudat or test or demo
+domain=eudat
+
+# institutes which this iRODS instance handles
+institutes=inst_a,inst_b
+
+[inst_a]
+# uid of the corresponding registered storage resource on DPMT 
+# (same as storage_space_uuid on RCT)
+account=<insert uid here>
+# username of the provider on the accouniting server
+# owning the account specified above
+# contact dp-admin@mpcdf.mpg.de if you need one
+user=<username of provider>
+# if you have an access token from RCT already reuse that here
+password=<password or access token>
+service_uuid=<unsuported at the moment>
+
+# section contains the list of collections to be accounted together, replace
+# the examples with your collections, the script sums the values of all
+# collections and sends it to EUDAT's accounting service.
+clist=
+  /vzx/eudat/A
+  /vzx/other/pathA
+
+[inst_b]
+# uid of the corresponding registered storage resource on DPMT 
+# (same as storage_space_uuid on RCT)
+account=<insert uid here>
+# username of the provider on the accouniting server
+# owning the account specified above
+# contact dp-admin@mpcdf.mpg.de if you need one
+user=<username of provider>
+# if you have an access token from RCT already reuse that here
+password=<password or access token>
+service_uuid=<unsuported at the moment>
+
+# section contains the list of collections to be accounted together, replace
+# the examples with your collections, the script sums the values of all
+# collections and sends it to EUDAT's accounting service.
+clist=
+  /vzx/eudat/B
+  /vzx/other/pathB


### PR DESCRIPTION
This is an enhancement on the EUDAT accounting client that allows the use of a config file that separates the data for different institutes, as requested (#1).
The main client Python code, iRODScollector.py has been changed, and a template for the new kind of config file supported is also included as irodscollector_multi.ini.
The changes are backward compatible, so the old config files should also work with the new code, as long as they have the right sections and options.